### PR TITLE
add jitter warning to readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,8 @@ Button Mash is an Input Display written mainly to display SNES controller input.
 
 It currently support SNES Classic hacked with Hakchi2 CE, Arduino based solution for real hardware (using Nintendo Spy firmware), Usb2Snes and regular controllers.
 
+Note: the USB handling of the FxPax/Sd2Snes has up to five frames of jitter at all times. If you're using one of those flash carts and you want an input display that is more accurate than that, you'll need a hardware device like a RetroSpy.
+
 # Skins
 
 Regular Skin follow Nintendo Spy format so you can reuse skin written for it (see https://github.com/jaburns/NintendoSpy)

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@ Button Mash is an Input Display written mainly to display SNES controller input.
 
 It currently support SNES Classic hacked with Hakchi2 CE, Arduino based solution for real hardware (using Nintendo Spy firmware), Usb2Snes and regular controllers.
 
-Note: the USB handling of the FxPax/Sd2Snes has up to five frames of jitter at all times. If you're using one of those flash carts and you want an input display that is more accurate than that, you'll need a hardware device like a RetroSpy.
+Note: if you're using a USB connection to an FxPak/Sd2Snes, the firmware will stop communicating for a period of about 5 frames, multiple times per second. This means the input display will not update during those times. If you need 100% accuracy, consider a hardware based input display solution (which Button Mash also supports) 
 
 # Skins
 


### PR DESCRIPTION
I spent a few hours the other day trying to set up input display over fxpak USB and I learned that it inherently has a ton of jitter with the current firmware, so it's no good for my use case. I would like to save others the trouble of learning this the hard way